### PR TITLE
Add Gamemodes & Location to Timolia Manifest

### DIFF
--- a/minecraft_servers/timolia/manifest.json
+++ b/minecraft_servers/timolia/manifest.json
@@ -31,61 +31,51 @@
       "command": "/quickjoin castles",
       "color": "#0095B0"
     },
-    },
      "uhc": {
       "name": "UHC",
       "command": "",
       "color": "#0095B0"
     },
-    }
      "suspicious": {
       "name": "Suspicious",
       "command": "",
       "color": "#0095B0"
     },
-    }
      "arcade": {
       "name": "Arcade",
       "command": "/quickjoin arcade",
       "color": "#0095B0"
     },
-    }
      "survivalquest": {
       "name": "SurvivalQuest",
       "command": "/quickjoin survivalquest",
       "color": "#0095B0"
     },
-    }
      "4rena": {
       "name": "4rena",
       "command": "/quickjoin 4rena",
       "color": "#0095B0"
     },
-    }
      "Splun": {
       "name": "Splun",
       "command": "/quickjoin splun",
       "color": "#0095B0"
     },
-    }
      "intime": {
       "name": "InTime",
       "command": "/quickjoin intime",
       "color": "#0095B0"
     },
-    }
      "brainbow": {
       "name": "BrainBow",
       "command": "/quickjoin brainbow",
       "color": "#0095B0"
     },
-    }
      "dna": {
       "name": "DNA",
       "command": "/quickjoin dna",
       "color": "#0095B0"
     },
-    }
      "mineception": {
       "name": "Mineception",
       "command": "/quickjoin mineception",


### PR DESCRIPTION
## Type of change

- [✅] Update directory of a server

## Further comments
I'm not sure if colour shouldn't be the colour of each item that represents the mode.
For example, for JumpWorld yellow because of the gold shoes.
![Screenshot 2021-08-26 141904](https://user-images.githubusercontent.com/69513317/130961382-881dc37d-1f68-46b6-8376-6779fbc3f530.png)


...and if there is no QuickJoin Command, should the field be removed or empty?
