### PR TITLE
remove user_stats

### DIFF
--- a/minecraft_servers/gommehd/manifest.json
+++ b/minecraft_servers/gommehd/manifest.json
@@ -19,6 +19,5 @@
   "discord": {
     "server_id": 433699842389180417,
     "rename_to_minecraft_name": true
-  },
-  "user_stats": "https://www.gommehd.net/player/index?playerName={userName}"
+  }
 }


### PR DESCRIPTION
With the rebuild of the forum Gomme has removed the player statistics, the link is no longer functional.
According to the community forum, it could be that this function comes back, but it is just currently not available -> https://www.gommehd.net/forum/threads/stats-api-nicht-mehr-verfuegbar.943549/#post-4416120
