### PR TITLE
Removing a domain from neruxvace

### DIFF
--- a/minecraft_servers/neruxvace/manifest.json
+++ b/minecraft_servers/neruxvace/manifest.json
@@ -5,7 +5,6 @@
   "server_wildcards": [
     "neruxvace.net",
     "%.nerux.net",
-    "thevace.net",
     "neruxvase.net"
   ],
   "supported_languages": [


### PR DESCRIPTION
## Type of change

- [x ] Update directory of a server

## Further comments

The domain "thevace.net" no longer belongs to NeruxVace since 29.07.23