### PR TITLE
Update OCTC store and remove location

### DIFF
--- a/minecraft_servers/octc/manifest.json
+++ b/minecraft_servers/octc/manifest.json
@@ -10,7 +10,7 @@
     ],
     "social": {
         "web": "https://oc.tc",
-        "web_shop": "https://oc.tc/donate",
+        "web_shop": "https://oc.tc/store",
         "twitter": "OvercastPGM",
         "discord": "https://discord.gg/octc",
         "youtube": "https://www.youtube.com/@OvercastNetwork"
@@ -48,11 +48,6 @@
         "primary": "#D7D2BF",
         "background": "#4C0704",
         "text": "#FFFFFF"
-    },
-    "location": {
-        "city": "Toronto",
-        "country": "Canada",
-        "country_code": "CA"
     },
     "yt_trailer": "-nZdZ5Dy2Io",
     "command_delay": 3000


### PR DESCRIPTION
## Type of change

- [ ] Add new directory for a server
- [X] Update directory of a server
- [ ] Documentation Update

## Checklist

- [X] I have read the [README](https://github.com/LabyMod/server-media/blob/master/README.md) doc
- [X] I have compressed the images appropriately (e.g. on https://tinypng.com)
- [X] I have created the manifest.json with the required values

## Further comments
It might be a better idea to let Laby guess the server's location instead of defining one that may become outdated.
Updated store link as OCC recently changed their link. There is a redirect in place for the old link, but there are no guarantees it will continue working in the future.
