### PR TITLE
Minehut - update website links

### DIFF
--- a/minecraft_servers/minehut/manifest.json
+++ b/minecraft_servers/minehut/manifest.json
@@ -10,9 +10,9 @@
 	  "en"
 	],
 	"social":{
-	  "web": "https://minehut.com",
-	  "web_shop": "https://minehut.com/shop/credits",
-	  "web_support": "https://minehut.com/support/form",
+	  "web": "https://app.minehut.com",
+	  "web_shop": "https://app.minehut.com/shop/credits",
+	  "web_support": "https://app.minehut.com/support/form",
 	  "twitter": "minehut",
 	  "tiktok": "minehut",
 	  "facebook": "MinehutServers",
@@ -24,7 +24,7 @@
 	  "playerservers":{
 		"name": "Player Servers",
 		"color": "#FFFFFF",
-		"url": "https://minehut.com/servers"
+		"url": "https://app.minehut.com/servers"
 	  }
 	},
 	"discord":{


### PR DESCRIPTION
Minehut apparently moved its website to the subdomain `app.minehut.com`

## Type of change

- [ ] Add new directory for a server
- [X] Update directory of a server
- [ ] Documentation Update

## Checklist

- [X] I have read the [README](https://github.com/LabyMod/server-media/blob/master/README.md) doc
- [X] I have created the manifest.json with the required values

## Further comments

Minehut apparently moved its website to the subdomain `app.minehut.com`. The main website is their own server listing, however, it contains external servers that are not part of its network.
