### PR TITLE
Updated amuria.de

### DIFF
--- a/minecraft_servers/amuria/manifest.json
+++ b/minecraft_servers/amuria/manifest.json
@@ -39,7 +39,7 @@
     "text": "#000000"
   },
   "location": {
-     "city": "Hessen",
+     "city": "Frankfurt",
      "country": "Germany",
      "country_code": "DE"
    }


### PR DESCRIPTION
fix: set "ocation.city" to "Frankfurt".

## Type of change

- [ ] Add new directory for a server
- [x] Update directory of a server
- [ ] Remove directory of a server
- [ ] Documentation Update

## Checklist

- [x] I have read the [README](https://github.com/LabyMod/server-media/blob/master/README.md) doc
- [x] I have compressed the images appropriately (e.g. on https://tinypng.com)
- [x] I have created the manifest.json with the required values

## Further comments

Amuria.de is now hosted in Frankfurt.

