### PR TITLE
Remove warnings from validate GitHub workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.number }}/merge
       - name: Validate images
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.number }}/merge
       - name: Get changed files

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,8 +22,7 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.number }}/merge
       - name: Get changed files
-        #uses: lots0logs/gh-action-get-changed-files@2.1.4
-        uses: Raik0707/gh-action-get-changed-files@feature/support-pr-target-event # Remove as soon as PR is merged
+        uses: lots0logs/gh-action-get-changed-files@2.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Add json


### PR DESCRIPTION
## Type of change

- [x] GitHub workflow Update

## Further comments
The validate workflow has a lot of warnings:
![](https://i.imgur.com/oesw2Rb.png)

To get rid of almost all of them I upgraded some dependencies:
- `actions/checkout` from v2 to v4
- `gh-action-get-changed-files` from `Raik0707/gh-action-get-changed-files@feature/support-pr-target-event` to [`lots0logs/gh-action-get-changed-files@2.2.2`](https://github.com/lots0logs/gh-action-get-changed-files/releases/tag/2.2.2) (because [PR with feature branch](https://github.com/lots0logs/gh-action-get-changed-files/pull/22) was merged and the origin repository uses a newer nodejs version):
  ```yml
  - name: Get changed files
    #uses: lots0logs/gh-action-get-changed-files@2.1.4
    uses: Raik0707/gh-action-get-changed-files@feature/support-pr-target-event # Remove as soon as PR is merged:
  ```