### PR TITLE
Remove larmelobby from gamemodes

### DIFF
--- a/minecraft_servers/superawesome/manifest.json
+++ b/minecraft_servers/superawesome/manifest.json
@@ -16,12 +16,6 @@
     "youtube": "https://www.youtube.com/channel/UClhOqD9GXk2zGHZRluDLIBQ"
   },
   "gamemodes": {
-    "larmelobby": {
-      "name": "Larmelobby",
-      "command": "/server larmelobby",
-      "color": "#306fdb",
-      "versions": "1.20.6<*"
-    },
     "shoppylobby": {
       "name": "Shoppylobby",
       "command": "/server shoppylobby",


### PR DESCRIPTION
Removed 'larmelobby' gamemode configuration from manifest. larmelobby is no longer a supported lobby/gamemode as it has been removed.

## Type of change

- [ ] Add new directory for a server
- [ ] Update directory of a server
- [ ] Remove directory of a server
- [x] Documentation Update

## Checklist

- [x] I have read the [README](https://github.com/LabyMod/server-media/blob/master/README.md) doc
- [x] I have compressed the images appropriately (e.g. on https://tinypng.com)
- [x] I have created the manifest.json with the required values

## Further comments

