### PR TITLE
updated outdated links in 17 server manifests

### DIFF
--- a/minecraft_servers/archmc/manifest.json
+++ b/minecraft_servers/archmc/manifest.json
@@ -9,8 +9,8 @@
        "en"
     ],
     "social": {
-      "web": "https://arch.lol",
-      "web_shop": "https://arch.lol/store",
+      "web": "https://arch.mc",
+      "web_shop": "https://arch.mc/store",
       "tiktok": "ruleyourowngame",
       "discord": "https://discord.gg/archmc",
       "youtube": "https://www.youtube.com/@RuleYourOwnGame"

--- a/minecraft_servers/armamc/manifest.json
+++ b/minecraft_servers/armamc/manifest.json
@@ -6,7 +6,7 @@
       "pt"
     ],
     "social": {
-      "web": "https://armamc.com",
+      "web": "https://armamc.net",
       "web_shop": "https://loja.armamc.com",
       "discord": "https://discord.gg/armamc",
       "youtube": "https://www.youtube.com/@armarealms",

--- a/minecraft_servers/blotcraft/manifest.json
+++ b/minecraft_servers/blotcraft/manifest.json
@@ -10,8 +10,7 @@
      "es"
   ],
   "social": {
-    "web": "https://web.blotcraft.com",
-    "web_shop": "https://blotcraft.shop",
+    "web_shop": "https://store.blotcraft.com",
     "twitter": "BlotCraft",
     "tiktok": "BløtCraft",
     "facebook": "BlotCraft",

--- a/minecraft_servers/cytooxien/manifest.json
+++ b/minecraft_servers/cytooxien/manifest.json
@@ -6,8 +6,8 @@
     "de", "en", "fr", "es", "ru", "da"
   ],
   "social": {
-    "web": "https://www.cytooxien.de",
-    "web_shop": "https://shop.cytooxien.de",
+    "web": "https://www.cytooxien.net",
+    "web_shop": "https://cytooxien.net/shop",
     "twitter": "Cytooxien",
     "discord": "https://discord.gg/cytooxien",
     "tiktok": "cytooxien_de",

--- a/minecraft_servers/endercraft/manifest.json
+++ b/minecraft_servers/endercraft/manifest.json
@@ -13,7 +13,7 @@
       "web_shop": "https://loja.endercraft.com.br/shop",
       "tiktok": "EnderCrafBR",
       "instagram": "EnderCraftBR",
-      "discord": "https://discord.gg/endercraftbr",
+      "discord": "https://discord.gg/endercraft",
       "youtube": "https://www.youtube.com/@endercraft_br"
     },
     "gamemodes": {

--- a/minecraft_servers/freakyville/manifest.json
+++ b/minecraft_servers/freakyville/manifest.json
@@ -8,7 +8,7 @@
   "social": {
     "web": "https://freakyville.dk",
     "web_shop": "https://shop.freakyville.dk",
-    "discord": "https://www.freakyville.dk/discord"
+    "discord": "https://discord.gg/freakyville"
   },
   "gamemodes": {
     "nprison": {

--- a/minecraft_servers/hielkemapsnetwork/manifest.json
+++ b/minecraft_servers/hielkemapsnetwork/manifest.json
@@ -9,7 +9,7 @@
     "web": "https://hielkemaps.com",
     "twitter": "HielkeMaps",
     "discord": "https://discord.com/invite/6RzKxbH",
-    "youtube": "https://www.youtube.com/@HielkeMinecraft"
+    "youtube": "https://www.youtube.com/@HielkeMaps"
   },
   "gamemodes": {
     "parkour": {

--- a/minecraft_servers/kaizen/manifest.json
+++ b/minecraft_servers/kaizen/manifest.json
@@ -7,7 +7,7 @@
   ],
   "social": {
     "web": "https://kaizenmc.gg",
-    "web_shop": "https://kaizenmc.gg/category/6lW9zF5tnW",
+    "web_shop": "https://kaizenmc.gg",
     "twitter": "RedeKaizenMC",
     "tiktok": "redekaizenmc",
     "instagram": "redekaizenmc",

--- a/minecraft_servers/krypticmc/manifest.json
+++ b/minecraft_servers/krypticmc/manifest.json
@@ -13,7 +13,7 @@
   "social": {
     "web": "https://krypticmc.net",
     "web_shop": "https://krypticmc.net/store",
-    "discord": "https://discord.com/invite/KnSFDA9EGS",
+    "discord": "https://discord.gg/PmuCDKgxkA",
     "youtube": "https://www.youtube.com/@KrypticMC"
   },
   "discord": {

--- a/minecraft_servers/labymod/manifest.json
+++ b/minecraft_servers/labymod/manifest.json
@@ -7,7 +7,7 @@
         "de"
     ],
     "social": {
-        "web": "https://labymod.net",
+        "web": "https://laby.net",
         "twitter": "labymod",
         "tiktok": "labymod",
         "discord": "https://discord.gg/labymod"

--- a/minecraft_servers/lostaroleros/manifest.json
+++ b/minecraft_servers/lostaroleros/manifest.json
@@ -13,7 +13,7 @@
       "web": "https://lostaroleros.com",
       "web_shop": "https://tienda.lostaroleros.com",
       "twitter": "LosTarolerosMC",
-      "discord": "https://discord.gg/comunidad-tarolera-707250934421520404"
+      "discord": "https://discord.gg/comunidad-tarolera-1229817169693511710"
     },
     "gamemodes": {
       "survival": {

--- a/minecraft_servers/mccisland/manifest.json
+++ b/minecraft_servers/mccisland/manifest.json
@@ -8,7 +8,7 @@
     "%.mccisland.com"
   ],
   "social": {
-    "web": "https://mccisland.net",
+    "web": "https://mcchampionship.com/island",
     "web_shop": "https://store.mccisland.net",
     "web_support": "https://support.mccisland.net",
     "twitter": "MCCisland_",

--- a/minecraft_servers/minehut/manifest.json
+++ b/minecraft_servers/minehut/manifest.json
@@ -10,7 +10,7 @@
 	  "en"
 	],
 	"social":{
-	  "web": "https://app.minehut.com",
+	  "web": "https://minehut.com",
 	  "web_shop": "https://app.minehut.com/shop/credits",
 	  "web_support": "https://app.minehut.com/support/form",
 	  "twitter": "minehut",

--- a/minecraft_servers/oceanias/manifest.json
+++ b/minecraft_servers/oceanias/manifest.json
@@ -6,11 +6,12 @@
         "en"
     ],
     "social": {
-        "web_shop": "https://store.oceanias.net",
+        "web": "https://www.oceanias.gg",
+        "web_shop": "https://www.oceanias.gg/store",
         "twitter": "oceaniasnetwork",
         "tiktok": "oceanias",
         "discord": "https://discord.gg/YP3qGFP2nf",
-        "youtube": "https://www.youtube.com/@webceanias"
+        "youtube": "https://www.youtube.com/@oceaniasnetwork"
     },
     "gamemodes": {
         "practice": {

--- a/minecraft_servers/potterworldmc/manifest.json
+++ b/minecraft_servers/potterworldmc/manifest.json
@@ -23,6 +23,5 @@
     "server_id": 116659877614452736,
     "rename_to_minecraft_name": false
   },
-    "user_stats": "https://potterworldmc.com/player/{userName}",
-    "yt_trailer": "YxMw0XugJc"
+    "user_stats": "https://potterworldmc.com/player/{userName}"
 }

--- a/minecraft_servers/spot/manifest.json
+++ b/minecraft_servers/spot/manifest.json
@@ -9,7 +9,7 @@
   ],
   "social": {
     "web": "https://spotgames.net",
-    "web_shop": "https://loja.spotgames.net",
+    "web_shop": "https://www.spotgames.net/loja",
     "web_support": "https://wiki.spotgames.net",
     "twitter": "spotgames_net",
     "tiktok": "spotgames.net",

--- a/minecraft_servers/zonecraft/manifest.json
+++ b/minecraft_servers/zonecraft/manifest.json
@@ -16,7 +16,7 @@
       "web": "https://www.zonecraft.es",
       "web_shop": "https://tienda.zonecraft.es",
       "twitter": "ZoneCraftES",
-      "discord": "https://discord.gg/zonecraft",
+      "discord": "https://discord.gg/zonecraft-424584809612836865",
       "youtube": "https://www.youtube.com/@ZoneCraftES",
       "instagram": "zonecraftes",
       "tiktok": "zonecraftes"


### PR DESCRIPTION
Checked the manifests of the servers on the first three pages of the LABY.net server directory (top 150 by players online, only those with 10+ players online and an entry in this repo: 76 servers). Every `direct_ip` still answers a server list ping — these are only dead or moved links.

Each replacement below was verified: Discord invites through the Discord invite API, everything else by following the link.

**Dead Discord invites**
| Server | old | new |
|---|---|---|
| endercraft | `discord.gg/endercraftbr` (unknown invite) | `discord.gg/endercraft` — "EnderCraft \| Servidor de Minecraft", 10.7k members |
| zonecraft | `discord.gg/zonecraft` (unknown invite) | `discord.gg/zonecraft-424584809612836865` — ZoneCraft, 44k members |
| krypticmc | `discord.com/invite/KnSFDA9EGS` (expired) | `discord.gg/PmuCDKgxkA` — from krypticmc.net/discord, 5.7k members |
| lostaroleros | invite of the old guild `707250934421520404` | `discord.gg/comunidad-tarolera-1229817169693511710` — from discord.lostaroleros.com |
| freakyville | `freakyville.dk/discord` (renders an empty page) | `discord.gg/freakyville` — FreakyVille, 14.3k members |

**Moved websites and shops**
| Server | old | new |
|---|---|---|
| archmc | `arch.lol`, `arch.lol/store` | `arch.mc`, `arch.mc/store` |
| armamc | `armamc.com` | `armamc.net` |
| cytooxien | `www.cytooxien.de`, `shop.cytooxien.de` | `www.cytooxien.net`, `cytooxien.net/shop` |
| oceanias | `store.oceanias.net` | `www.oceanias.gg/store`, plus the missing `web` |
| spot | `loja.spotgames.net` (lands on the homepage) | `www.spotgames.net/loja` |
| kaizen | `kaizenmc.gg/category/6lW9zF5tnW` (404) | `kaizenmc.gg` |
| blotcraft | `blotcraft.shop` (no DNS) | `store.blotcraft.com` |
| mccisland | `mccisland.net` | `mcchampionship.com/island` |
| minehut | `app.minehut.com` (login wall) | `minehut.com` |
| labymod | `labymod.net` | `laby.net` |

**Removed**
- `blotcraft` `web`: `web.blotcraft.com` has no DNS record and `www.blotcraft.com` answers a plain 403, so the server currently has no working website. The shop above still works.
- `oceanias` YouTube `@webceanias` -> `@oceaniasnetwork` (the old handle 404s), `hielkemapsnetwork` `@HielkeMinecraft` -> `@HielkeMaps`.
- `potterworldmc` `yt_trailer`: `YxMw0XugJc` is ten characters, so it is not a valid video id and the embed cannot resolve. Dropped rather than guessed.

**Found but not touched — these need a decision, not an edit**
- `warfaremc` is now **Mythara**: `warfaremc.eu` redirects to `mythara.cz` and the MOTD on `mc.warfaremc.eu` reads "Mythara". Name, directory and every link would change.
- `wasd` is now **Heeph**: `loja.wasdmc.com` serves the Heeph store and `wasdmc.com` pings with the Heeph MOTD, so it duplicates the existing `heeph` entry.
- `frizz`: `frizzmc.com` answers 502 and `discord.com/invite/frizzmc` is gone, but the server itself is still up.
- `mush`: the YouTube handle `@MushNetwork` 404s; `mush.com.br` is behind a bot check, so I could not find the current channel.

Sites that answer 403 to a scripted request (Cloudflare/Tebex bot protection) were checked in a browser and are fine — they are not part of this PR.