### PR TITLE
removed the dead user stats link from cytooxien

### DIFF
--- a/minecraft_servers/cytooxien/manifest.json
+++ b/minecraft_servers/cytooxien/manifest.json
@@ -17,7 +17,6 @@
   "discord": {
     "server_id": 443768116216987648
   },
-  "user_stats": "https://stats.cytooxien.de/player/{userName}",
   "gamemodes": {
     "onlyup": {
       "name": "Only Up!",


### PR DESCRIPTION
`stats.cytooxien.de` no longer resolves at all — the subdomain has no DNS record — so the player stats button on the server page led nowhere.

There is no working replacement to point it at: `cytooxien.net/en/stats` and `/en/player/<name>` both answer 404, and `stats.cytooxien.net` answers a 525 (Cloudflare cannot reach the origin). So the field is removed rather than redirected; it is one line to add back once the server has a stats page again.

Nothing else in the manifest is touched.