### PR TITLE
added game modes to 34 servers

### DIFF
--- a/minecraft_servers/akumamc/manifest.json
+++ b/minecraft_servers/akumamc/manifest.json
@@ -17,5 +17,15 @@
   },
   "brand": {
     "primary": "#FFB92C"
+  },
+  "gamemodes": {
+    "prison": {
+      "name": "Prison",
+      "color": "#FFB92C"
+    },
+    "skyblock": {
+      "name": "Skyblock",
+      "color": "#FFB92C"
+    }
   }
 }

--- a/minecraft_servers/archmc/manifest.json
+++ b/minecraft_servers/archmc/manifest.json
@@ -23,5 +23,11 @@
        "primary": "#008FE8",
        "background": "#0A56A5",
        "text": "#FFFFFF"
+    },
+    "gamemodes": {
+        "lifesteal": {
+            "name": "Lifesteal",
+            "color": "#008FE8"
+        }
     }
 }

--- a/minecraft_servers/astralmc/manifest.json
+++ b/minecraft_servers/astralmc/manifest.json
@@ -14,5 +14,19 @@
   },
   "brand": {
     "primary": "#FE3BD3"
+  },
+  "gamemodes": {
+    "kitmap": {
+      "name": "KitMap",
+      "color": "#FE3BD3"
+    },
+    "hcf": {
+      "name": "HCF",
+      "color": "#FE3BD3"
+    },
+    "leagues": {
+      "name": "Leagues",
+      "color": "#FE3BD3"
+    }
   }
 }

--- a/minecraft_servers/bedwarspractice/manifest.json
+++ b/minecraft_servers/bedwarspractice/manifest.json
@@ -13,5 +13,11 @@
     "brand": {
         "primary": "#131313",
         "background": "#b3001b"
+    },
+    "gamemodes": {
+        "bedwarspractice": {
+            "name": "BedWars Practice",
+            "color": "#131313"
+        }
     }
 }

--- a/minecraft_servers/castiamc/manifest.json
+++ b/minecraft_servers/castiamc/manifest.json
@@ -18,5 +18,15 @@
   },
   "brand": {
     "primary": "#BE3A08"
+  },
+  "gamemodes": {
+    "towny": {
+      "name": "Towny",
+      "color": "#BE3A08"
+    },
+    "survival": {
+      "name": "Survival",
+      "color": "#BE3A08"
+    }
   }
 }

--- a/minecraft_servers/catpvp/manifest.json
+++ b/minecraft_servers/catpvp/manifest.json
@@ -16,5 +16,19 @@
   },
   "brand": {
     "primary": "#7F3400"
+  },
+  "gamemodes": {
+    "duels": {
+      "name": "Duels",
+      "color": "#7F3400"
+    },
+    "ffa": {
+      "name": "FFA",
+      "color": "#7F3400"
+    },
+    "sandbox": {
+      "name": "Sandbox",
+      "color": "#7F3400"
+    }
   }
 }

--- a/minecraft_servers/coldgames/manifest.json
+++ b/minecraft_servers/coldgames/manifest.json
@@ -16,5 +16,15 @@
   },
   "brand": {
     "primary": "#0EC5DB"
+  },
+  "gamemodes": {
+    "lifesteal": {
+      "name": "Lifesteal",
+      "color": "#0EC5DB"
+    },
+    "duels": {
+      "name": "Duels",
+      "color": "#0EC5DB"
+    }
   }
 }

--- a/minecraft_servers/donutsmp/manifest.json
+++ b/minecraft_servers/donutsmp/manifest.json
@@ -15,5 +15,11 @@
   },
   "brand": {
     "primary": "#036FFF"
+  },
+  "gamemodes": {
+    "smp": {
+      "name": "SMP",
+      "color": "#036FFF"
+    }
   }
 }

--- a/minecraft_servers/earthmc/manifest.json
+++ b/minecraft_servers/earthmc/manifest.json
@@ -16,5 +16,11 @@
   },
   "brand": {
     "primary": "#355DC3"
+  },
+  "gamemodes": {
+    "earth": {
+      "name": "Earth",
+      "color": "#355DC3"
+    }
   }
 }

--- a/minecraft_servers/elevatemc/manifest.json
+++ b/minecraft_servers/elevatemc/manifest.json
@@ -15,5 +15,11 @@
   },
   "brand": {
     "primary": "#1CDDCA"
+  },
+  "gamemodes": {
+    "potpvp": {
+      "name": "PotPvP",
+      "color": "#1CDDCA"
+    }
   }
 }

--- a/minecraft_servers/enchantedmc/manifest.json
+++ b/minecraft_servers/enchantedmc/manifest.json
@@ -16,5 +16,11 @@
   },
   "brand": {
     "primary": "#D24CA9"
+  },
+  "gamemodes": {
+    "prison": {
+      "name": "Prison",
+      "color": "#D24CA9"
+    }
   }
 }

--- a/minecraft_servers/essencemc/manifest.json
+++ b/minecraft_servers/essencemc/manifest.json
@@ -15,5 +15,11 @@
   },
   "brand": {
     "primary": "#31214F"
+  },
+  "gamemodes": {
+    "gens": {
+      "name": "Gens",
+      "color": "#31214F"
+    }
   }
 }

--- a/minecraft_servers/fishonmc/manifest.json
+++ b/minecraft_servers/fishonmc/manifest.json
@@ -15,5 +15,11 @@
   },
   "brand": {
     "primary": "#1DBDF5"
+  },
+  "gamemodes": {
+    "fishing": {
+      "name": "Fishing",
+      "color": "#1DBDF5"
+    }
   }
 }

--- a/minecraft_servers/flaremc/manifest.json
+++ b/minecraft_servers/flaremc/manifest.json
@@ -15,5 +15,15 @@
   },
   "brand": {
     "primary": "#E95817"
+  },
+  "gamemodes": {
+    "lifesteal": {
+      "name": "Lifesteal",
+      "color": "#E95817"
+    },
+    "survival": {
+      "name": "Survival",
+      "color": "#E95817"
+    }
   }
 }

--- a/minecraft_servers/flowerrealms/manifest.json
+++ b/minecraft_servers/flowerrealms/manifest.json
@@ -15,5 +15,11 @@
   },
   "brand": {
     "primary": "#F8BC14"
+  },
+  "gamemodes": {
+    "gentycoon": {
+      "name": "Gen Tycoon",
+      "color": "#F8BC14"
+    }
   }
 }

--- a/minecraft_servers/hoplite/manifest.json
+++ b/minecraft_servers/hoplite/manifest.json
@@ -20,5 +20,11 @@
     "background": "#497cb1",
     "text": "#ffffff"
   },
-  "yt_trailer": "w3FALZ38NFQ"
+  "yt_trailer": "w3FALZ38NFQ",
+  "gamemodes": {
+    "duels": {
+      "name": "Duels",
+      "color": "#497cb1"
+    }
+  }
 }

--- a/minecraft_servers/hugosmp/manifest.json
+++ b/minecraft_servers/hugosmp/manifest.json
@@ -21,5 +21,11 @@
   "location": {
      "country": "Germany",
      "country_code": "DE"
+  },
+  "gamemodes": {
+    "smp": {
+      "name": "SMP",
+      "color": "#A0010C"
+    }
   }
 }

--- a/minecraft_servers/kokscraft/manifest.json
+++ b/minecraft_servers/kokscraft/manifest.json
@@ -20,5 +20,11 @@
   "brand": {
      "primary": "#2a2a2a",
      "background": "#ff6301"
+  },
+  "gamemodes": {
+    "kitpvp": {
+      "name": "KitPvP",
+      "color": "#2a2a2a"
+    }
   }
 }

--- a/minecraft_servers/lifestealsmp/manifest.json
+++ b/minecraft_servers/lifestealsmp/manifest.json
@@ -18,5 +18,11 @@
   },
   "brand": {
     "primary": "#9CE86F"
+  },
+  "gamemodes": {
+    "lifesteal": {
+      "name": "Lifesteal",
+      "color": "#9CE86F"
+    }
   }
 }

--- a/minecraft_servers/mcchallenges/manifest.json
+++ b/minecraft_servers/mcchallenges/manifest.json
@@ -21,5 +21,11 @@
     "city": "Munich",
     "country": "Germany",
     "country_code": "DE"
+  },
+  "gamemodes": {
+    "challenges": {
+      "name": "Challenges",
+      "color": "#163451"
+    }
   }
 }

--- a/minecraft_servers/mcmanhunt/manifest.json
+++ b/minecraft_servers/mcmanhunt/manifest.json
@@ -18,5 +18,11 @@
   },
   "brand": {
     "primary": "#FFEF23"
+  },
+  "gamemodes": {
+    "manhunt": {
+      "name": "Manhunt",
+      "color": "#FFEF23"
+    }
   }
 }

--- a/minecraft_servers/mcpvpclub/manifest.json
+++ b/minecraft_servers/mcpvpclub/manifest.json
@@ -15,5 +15,19 @@
   },
   "brand": {
     "primary": "#FF1C33"
+  },
+  "gamemodes": {
+    "duels": {
+      "name": "Duels",
+      "color": "#FF1C33"
+    },
+    "ffa": {
+      "name": "FFA",
+      "color": "#FF1C33"
+    },
+    "teams": {
+      "name": "Teams",
+      "color": "#FF1C33"
+    }
   }
 }

--- a/minecraft_servers/mineage/manifest.json
+++ b/minecraft_servers/mineage/manifest.json
@@ -15,5 +15,15 @@
   },
   "brand": {
     "primary": "#59E3EB"
+  },
+  "gamemodes": {
+    "hcf": {
+      "name": "HCF",
+      "color": "#59E3EB"
+    },
+    "factions": {
+      "name": "Factions",
+      "color": "#59E3EB"
+    }
   }
 }

--- a/minecraft_servers/mineplex/manifest.json
+++ b/minecraft_servers/mineplex/manifest.json
@@ -17,5 +17,87 @@
     "primary": "#497cb1",
     "background": "#497cb1",
     "text": "#ffffff"
+  },
+  "gamemodes": {
+    "block_hunt": {
+      "name": "Block Hunt",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/block-hunt"
+    },
+    "cake_wars": {
+      "name": "Cake Wars",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/cake-wars"
+    },
+    "champions": {
+      "name": "Champions",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/champions"
+    },
+    "clans": {
+      "name": "Clans",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/clans"
+    },
+    "dragon_escape": {
+      "name": "Dragon Escape",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/dragon-escape"
+    },
+    "micro_battle": {
+      "name": "Micro Battle",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/micro-battle"
+    },
+    "minestrike": {
+      "name": "MineStrike",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/minestrike"
+    },
+    "mixed_arcade": {
+      "name": "Mixed Arcade",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/mixed-arcade"
+    },
+    "nano_games": {
+      "name": "Nano Games",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/nano-games"
+    },
+    "one_block": {
+      "name": "One Block",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/one-block"
+    },
+    "speed_builders": {
+      "name": "Speed Builders",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/speed-builders"
+    },
+    "super_paintball": {
+      "name": "Super Paintball",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/super-paintball"
+    },
+    "super_smash_mobs": {
+      "name": "Super Smash Mobs",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/super-smash-mobs"
+    },
+    "survival_games": {
+      "name": "Survival Games",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/survival-games"
+    },
+    "the_bridges": {
+      "name": "The Bridges",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/the-bridges"
+    },
+    "turf_wars": {
+      "name": "Turf Wars",
+      "color": "#497cb1",
+      "url": "https://www.mineplex.com/games/turf-wars"
+    }
   }
 }

--- a/minecraft_servers/og-network/manifest.json
+++ b/minecraft_servers/og-network/manifest.json
@@ -13,5 +13,11 @@
   "brand": {
      "primary": "#151f38",
      "background": "#58ff87"
+  },
+  "gamemodes": {
+    "rpgsmp": {
+      "name": "RPG-SMP",
+      "color": "#151f38"
+    }
   }
 }

--- a/minecraft_servers/opsucht/manifest.json
+++ b/minecraft_servers/opsucht/manifest.json
@@ -35,5 +35,11 @@
     "country": "Germany",
     "country_code": "DE"
   },
-  "yt_trailer": "O7Zdr6ZygNo"
+  "yt_trailer": "O7Zdr6ZygNo",
+  "gamemodes": {
+    "citybuild": {
+      "name": "CityBuild",
+      "color": "#0095ed"
+    }
+  }
 }

--- a/minecraft_servers/pvplegacy/manifest.json
+++ b/minecraft_servers/pvplegacy/manifest.json
@@ -14,5 +14,19 @@
     "brand": {
         "primary": "#131313",
         "background": "#217dba"
+    },
+    "gamemodes": {
+        "duels": {
+            "name": "Custom Duels",
+            "color": "#131313"
+        },
+        "minigames": {
+            "name": "Minigames",
+            "color": "#131313"
+        },
+        "crystalffa": {
+            "name": "Crystal FFA",
+            "color": "#131313"
+        }
     }
 }

--- a/minecraft_servers/signalsmp/manifest.json
+++ b/minecraft_servers/signalsmp/manifest.json
@@ -14,5 +14,11 @@
   },
   "brand": {
     "primary": "#F9E133"
+  },
+  "gamemodes": {
+    "survival": {
+      "name": "Survival",
+      "color": "#F9E133"
+    }
   }
 }

--- a/minecraft_servers/skyblock/manifest.json
+++ b/minecraft_servers/skyblock/manifest.json
@@ -17,5 +17,11 @@
   },
   "brand": {
     "primary": "#79E7FC"
+  },
+  "gamemodes": {
+    "skyblock": {
+      "name": "Skyblock",
+      "color": "#79E7FC"
+    }
   }
 }

--- a/minecraft_servers/sunrealms/manifest.json
+++ b/minecraft_servers/sunrealms/manifest.json
@@ -14,5 +14,11 @@
   },
   "brand": {
     "primary": "#FBB93A"
+  },
+  "gamemodes": {
+    "gens": {
+      "name": "Gens",
+      "color": "#FBB93A"
+    }
   }
 }

--- a/minecraft_servers/ultimis/manifest.json
+++ b/minecraft_servers/ultimis/manifest.json
@@ -18,5 +18,11 @@
   "discord": {
     "server_id": 621655047905869848
   },
-  "yt_trailer": "000fYpUpEsk"
+  "yt_trailer": "000fYpUpEsk",
+  "gamemodes": {
+    "skymines": {
+      "name": "SkyMines",
+      "color": "#008FE8"
+    }
+  }
 }

--- a/minecraft_servers/wildnetwork/manifest.json
+++ b/minecraft_servers/wildnetwork/manifest.json
@@ -18,5 +18,15 @@
   },
   "brand": {
     "primary": "#FDF70F"
+  },
+  "gamemodes": {
+    "survival": {
+      "name": "Survival",
+      "color": "#FDF70F"
+    },
+    "prison": {
+      "name": "Prison",
+      "color": "#FDF70F"
+    }
   }
 }

--- a/minecraft_servers/wynncraft/manifest.json
+++ b/minecraft_servers/wynncraft/manifest.json
@@ -22,5 +22,11 @@
     "rename_to_minecraft_name": false
   },
   "yt_trailer": "mt6EdX76JR4",
-  "user_stats": "https://wynncraft.com/stats/player/{userName}"
+  "user_stats": "https://wynncraft.com/stats/player/{userName}",
+  "gamemodes": {
+    "mmorpg": {
+      "name": "MMORPG",
+      "color": "#A7EB64"
+    }
+  }
 }

--- a/minecraft_servers/zedarmc/manifest.json
+++ b/minecraft_servers/zedarmc/manifest.json
@@ -14,5 +14,11 @@
   },
   "brand": {
     "primary": "#F537F6"
+  },
+  "gamemodes": {
+    "smp": {
+      "name": "SMP",
+      "color": "#F537F6"
+    }
   }
 }


### PR DESCRIPTION
Went through the top 100 servers by players online and checked which ones carry no `gamemodes` at all: 51 did not, so they cannot be found through the directory's mode filter. 34 of them state their modes clearly enough to enter.

**Every mode is one the server names itself**, in its own wording, from its own site or MOTD. Nothing is inferred from screenshots or third party listings.

| Source | Servers |
|---|---|
| own game pages, kept as the mode `url` | mineplex (16 modes) |
| page title | wynncraft (MMORPG), fishonmc (Fishing), castiamc (Towny, Survival), flowerrealms (Gen Tycoon), mcmanhunt (Manhunt), mcchallenges (Challenges), earthmc (Earth), skyblock (Skyblock), lifestealsmp (Lifesteal) |
| MOTD | catpvp (Duels, FFA, Sandbox), mcpvpclub (Duels, FFA, Teams), pvplegacy (Custom Duels, Minigames, Crystal FFA), mineage (HCF, Factions), wildnetwork (Survival, Prison), flaremc (Lifesteal, Survival), coldgames (Lifesteal, Duels), opsucht (CityBuild), archmc (Lifesteal), enchantedmc (Prison), kokscraft (KitPvP), hoplite (Duels), sunrealms (Gens), essencemc (Gens), ultimis (SkyMines), elevatemc (PotPvP), signalsmp (Survival), og-network (RPG-SMP), donutsmp (SMP), akumamc (Prison, Skyblock) |
| mode banners on the site | astralmc (KitMap, HCF, Leagues) |
| the server name | hugosmp (SMP), zedarmc (SMP), bedwarspractice (BedWars Practice) |

A server whose whole identity is one mode still gets that one mode. Without it, it is invisible to the mode filter, which is worse than a short list.

Modes carry the server's brand colour. None of these sites publishes a colour per mode, and inventing a palette would be worse than one honest accent. Mineplex's mode urls were checked and answer 200.

**Deliberately left out**: servers that name no mode anywhere (2b2t, Constantiam, Stray, LeoneMC, Sharpness), multi mode networks where only the current season is advertised and listing that alone would misrepresent them (MCCentral, UniversoCraft, OriginRealms), and HorusMC, whose site now serves a differently named server. CatPvP's site shows eight server icons that look like modes, but those are other servers its hub links to, so they are not here.

The manifests are edited textually rather than re-serialised, so files with CRLF, four space indent or no trailing newline keep their formatting and the diff stays additive.
