### PR TITLE
Add marsmc.net aliases to MarsPixel

### DIFF
--- a/minecraft_servers/marspixel/manifest.json
+++ b/minecraft_servers/marspixel/manifest.json
@@ -3,7 +3,10 @@
     "nice_name": "MarsPixel",
     "direct_ip": "play.marspixel.net",
     "server_wildcards": [
-      "%.marspixel.net"
+      "%.marspixel.net",
+      "%.marsmc.net",
+      "marsmc.net",
+      "marsmc"
     ],
     "supported_languages": [
       "ar",


### PR DESCRIPTION
MarsPixel is the current brand of the network that previously ran as MarsMC on `marsmc.net`. Both domains point at the same backend and answer the server list ping with the same MOTD, so players joining through the old address belong to this entry.

Adds the old domain and its subdomains to `server_wildcards`, plus the bare `marsmc` slug so the old directory URL resolves here instead of to a separate entry.